### PR TITLE
Enable optional AI opponents for the King of Montenegro game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # King of Montenegro
 
-This repository contains a minimal implementation of the card game **King of Montenegro** using `pygame`.
+This repository contains an implementation of the card game **King of Montenegro** using `pygame`.
 
 ## Requirements
 
@@ -29,7 +29,11 @@ Run the game with:
 python game.py
 ```
 
-A window will open showing each player's hand. The game logic is largely text-driven: players enter commands in the terminal while the graphical window displays the cards. The implemented rules cover basic duels and collecting armies. The structure allows loading AI opponents in the future, but currently both players are human controlled.
+To play against the included example AI opponent, run:
 
-This is a simplified reference implementation and does not cover every nuance from the full rule set, but it provides a starting point for further development.
+```bash
+python game.py --ai ai_random
+```
+
+A window will open showing each player's hand. The game logic is primarily text-driven: players enter commands in the terminal while the graphical window displays the cards. By default the game starts with two human players, but the `--ai` option loads an AI module for the second player.
 

--- a/ai_random.py
+++ b/ai_random.py
@@ -1,0 +1,14 @@
+import random
+
+class AI:
+    def choose_action(self, game, player, reveal, pile):
+        """Return an action string like the human input."""
+        if not pile:
+            idx = random.randrange(len(player.hand))
+            return f'play {idx}'
+        actions = ['call', 'concede', 'play']
+        choice = random.choice(actions)
+        if choice == 'play':
+            idx = random.randrange(len(player.hand))
+            return f'play {idx}'
+        return choice


### PR DESCRIPTION
## Summary
- add an example `ai_random` module implementing a tiny AI
- extend `game.py` to optionally load an AI module
- update README with instructions for using an AI opponent

## Testing
- `python -m py_compile ai_random.py game.py cards.py render_cards.py`
- `SDL_VIDEODRIVER=dummy python game.py --ai ai_random` *(fails: waiting for player input but no import errors)*
- `pip install pygame`


------
https://chatgpt.com/codex/tasks/task_e_68436a4d6bd88321a55d2ed9b2946d9f